### PR TITLE
Make the extension compatible with Doctrine docs

### DIFF
--- a/lib/symfony-extension/src/Directives/ConfigurationBlockDirective.php
+++ b/lib/symfony-extension/src/Directives/ConfigurationBlockDirective.php
@@ -14,6 +14,8 @@ use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 class ConfigurationBlockDirective extends SubDirective
 {
     private const LANGUAGE_LABELS = [
+        'annotation' => 'Annotations',
+        'attribute' => 'Attributes',
         'caddy' => 'Caddy',
         'env' => 'Bash',
         'html+jinja' => 'Twig',

--- a/lib/symfony-extension/src/Highlighter/Highlighter.php
+++ b/lib/symfony-extension/src/Highlighter/Highlighter.php
@@ -9,6 +9,8 @@ use Psr\Log\LoggerInterface;
 final class Highlighter
 {
     private const LANGUAGES_MAPPING = [
+        'annotation' => 'php',
+        'attribute' => 'php',
         'env' => 'bash',
         'html+jinja' => 'twig',
         'html+twig' => 'twig',


### PR DESCRIPTION
Doctrine uses slightly different language mappings than Symfony does. Maybe we could deprecate one in favor of the other in the future. For now, let us handle both situations.